### PR TITLE
feat: list all chains contract was verified on

### DIFF
--- a/src/components/ui/VerifiedContract.tsx
+++ b/src/components/ui/VerifiedContract.tsx
@@ -12,7 +12,10 @@ interface Props {
 
 export const VerifiedContract = ({ data }: Props) => {
   // -------- Verification Data Formatting --------
-  const defaultChain = Object.keys(data.matches)[0];
+  const matchingChains = Object.keys(data.matches);
+
+  const numMatches = matchingChains.length;
+  const defaultChain = matchingChains[0];
   const contractName =
     data.compiler_info.settings.compilationTarget[
       Object.keys(data.compiler_info.settings.compilationTarget)[0]
@@ -104,10 +107,13 @@ export const VerifiedContract = ({ data }: Props) => {
           </div>
           <div className='ml-3'>
             <h3 className='text-sm font-medium text-green-800 dark:text-green-100'>
-              Verification successful!
+              Verification successful on {numMatches} chain{numMatches !== 1 && 's'}!
             </h3>
             <div className='mt-1 text-xs text-green-700 dark:text-green-200'>
-              <p>Showing data for {defaultChain}</p>
+              <p>Verified on {matchingChains.join(', ')}.</p>
+              <p className='mt-1'>
+                Showing data for <span className='font-bold'>{defaultChain}</span>.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The green successful verification box was the only thing changed here to list all chains it was verified on. You can test with the below (both use foundry default profile):
- Contract deployed on one chain: repo
https://github.com/gitcoinco/Alpha-Governor-Upgrade, commit 17f7717eec0604505da2faf3f65516a8619063a0, address 0x1a84384e1f1b12d53e60c8c528178dc87767b488, Mainnet 0x61d669c6c0b976637b8f4528b99b170f060227b2bc20892743f22c6a34c84e23
- Contract deployed on multiple chains: repo https://github.com/ScopeLift/cove-test-repo, commit b268862cf1ccf495d6dc20a86c41940dfb386d9b, address 0x8d56e3e001132d84488dbacdbb01afb8c3171242, Goerli 0x59724cfbee93a0c10f7cbd312c1d159d62ea602003dd61a407a5cf842b4103d6, Sepolia 0xf9899c9d982e7a7d074f6792c3689b1c0a25d14eaa9f065ce31bfa4ea59607b2

One chain:
<img width="389" alt="image" src="https://github.com/ScopeLift/cove-frontend/assets/17163988/824c4a56-77e4-4b4f-9d05-a9d62aea6459">

Multi-chain:
<img width="390" alt="image" src="https://github.com/ScopeLift/cove-frontend/assets/17163988/5cd26fc5-b05c-4427-b0bd-506127953b1b">
